### PR TITLE
Fix startup mem leaks with config and device manager

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -72,7 +72,7 @@ void Config::Load()
 	blog(LOG_INFO, "Loaded: \n %s",
 	     config_get_string(obsConfig, SECTION_NAME, PARAM_DEVICES));
 	deviceManager->Load(deviceManagerData);
-
+	obs_data_release(deviceManagerData);
 	SettingsLoaded = true;
 }
 

--- a/src/device-manager.cpp
+++ b/src/device-manager.cpp
@@ -43,6 +43,7 @@ void DeviceManager::Load(obs_data_t *data)
 		obs_data_t *deviceData = obs_data_array_item(devicesData, i);
 		MidiAgent *device = new MidiAgent();
 		device->Load(deviceData);
+		obs_data_release(deviceData);
 		midiAgents.push_back(device);
 
 		connect(this, SIGNAL(bcast(QString, QString)), device,
@@ -61,6 +62,8 @@ void DeviceManager::Load(obs_data_t *data)
 			}
 		}
 	}
+
+	obs_data_array_release(devicesData);
 }
 
 void DeviceManager::Unload()


### PR DESCRIPTION
Fixed 3 mem-leaks reported by OBS logs on plugins load